### PR TITLE
Fix name backend env variable in Readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Those informations will be passed on to associations and organizations that are 
    ```
 4. In your `backend` repo, create and edit a new file called `.env` with the following content:
     ```.env
-    DB_HOST=mongodb://127.0.0.1:27017/find-shelter
+    DB_URL=mongodb://127.0.0.1:27017/find-shelter
     CORS_ORIGIN=http://localhost:8080
     ```
 5. In your `frontend` repo, create and edit a new file called `.env.local` with the following content:


### PR DESCRIPTION
Fix the env variable name in README file as per variable name in [backend config file](https://github.com/fabrahaingo/find-shelter/blob/8b25333c210d76f72fa279b9b521a75360e11392/back/config/db.config.js#L2)